### PR TITLE
fix: remove public_repo from the github scopes

### DIFF
--- a/django/peoplebackend/settings.py
+++ b/django/peoplebackend/settings.py
@@ -158,8 +158,7 @@ SOCIALACCOUNT_PROVIDERS = {
     'github': {
         'SCOPE': [
             'read:user',
-            'user:email',
-            'public_repo'
+            'user:email'
         ],
     }
 }


### PR DESCRIPTION
fixes #11 