### PR TITLE
fix: remove white-space nowrap on UserAvatar

### DIFF
--- a/frontend/components/UserAvatar.vue
+++ b/frontend/components/UserAvatar.vue
@@ -104,6 +104,7 @@ export default {
       .email {
         color: @font-dark-secondary;
         .text-truncate();
+        white-space: unset !important;
       }
     }
 


### PR DESCRIPTION
I have a huge e-mail address. Without wrap on white-space, my e-mail gets partially hidden on UserAvatar. (image above)

This PR fixes this behavior

![image](https://user-images.githubusercontent.com/9141449/41255964-9d19dd52-6d9e-11e8-9232-8b3c4ab2211a.png)
